### PR TITLE
Second version

### DIFF
--- a/umn_cookie_audit.rb
+++ b/umn_cookie_audit.rb
@@ -52,7 +52,7 @@ def new_browser(headless:, timeout:)
     headless: headless,
     timeout: timeout,
     browser_path: browser_path,
-    browser_options: { 'no-sandbox' => nil, 'disable-dev-shm-usage' => nil }
+    browser_options: { "no-sandbox": nil, "disable-dev-shm-usage": nil }
   )
 end
 


### PR DESCRIPTION
Roll in some updated features to the UMN Cookie Audit.

a0530ad933709df160e89f4095f4da1108d4bd4b - Use the Library's CookieCutter suspected patterns and literals.
778b291c3fd9e9bcab80e2f0606d994982c2d1ce - Simple syntax change to newer standard.
ced1cd443df6dcd24aef8e0287924b20cb0557c9 - Add a `--seperator` option for dividing CSV content. Newlines looked nicer in CSV output.
c1527def133a6c73d74157775f359218558df6cf - Change terminal output to add color and icons with the status of scans sites. Notable, the line for each site gets added after the scan now rather than when the scan is starting. This allows the result to be included in the output.
b0360b2c7d60518e620cc3e3c48030800c9220a5 - Adds thread pools and allows faster scans.
23d656fc01185cb9eb439b9b0c9aebf398843ca2 - Update documentation to reflect the changes in version two.
